### PR TITLE
simplify devise user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
-  # :trackable, :timeoutable and :omniauthable
-  devise :lockable, :confirmable, :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  # :lockable, :confirmable, :database_authenticatable, :registerable,
+  # :recoverable, :validatable, :trackable, :timeoutable and :omniauthable
+  devise :trackable, :rememberable
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -238,7 +238,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  config.omniauth :github, '63ff4e513cfd84b286df', '0d742c23e022349903cc2ad83c62bae343252a70', scope: 'user,public_repo'
+  config.omniauth :github, '51047e5db47cba9b15c6', '1230f0f421714c8fe47d9b2566a5d7e98b35ded1', scope: 'user'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/db/migrate/20150814000537_create_users.rb
+++ b/db/migrate/20150814000537_create_users.rb
@@ -1,8 +1,11 @@
+# Most from:
+#   rails g model User name admin:boolean email
 class CreateUsers < ActiveRecord::Migration
   def change
     create_table :users do |t|
-      t.string :name, null: false
+      t.string  :name,  null: false
       t.boolean :admin, null: false, default: false
+      t.string  :email, null: false, default: ''
 
       t.timestamps null: false
     end

--- a/db/migrate/20150814004520_add_devise_to_users.rb
+++ b/db/migrate/20150814004520_add_devise_to_users.rb
@@ -2,43 +2,43 @@ class AddDeviseToUsers < ActiveRecord::Migration
   def self.up
     change_table(:users) do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      # t.string :email,              null: false, default: ""
+      # t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable
-      t.string   :reset_password_token
-      t.datetime :reset_password_sent_at
+      # t.string   :reset_password_token
+      # t.datetime :reset_password_sent_at
 
       ## Rememberable
       t.datetime :remember_created_at
 
       ## Trackable
-      # t.integer  :sign_in_count, default: 0, null: false
-      # t.datetime :current_sign_in_at
-      # t.datetime :last_sign_in_at
-      # t.string   :current_sign_in_ip
-      # t.string   :last_sign_in_ip
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
 
-      # Confirmable
-      t.string   :confirmation_token
-      t.datetime :confirmed_at
-      t.datetime :confirmation_sent_at
-      t.string   :unconfirmed_email # Only if using reconfirmable
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
-      t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
-      t.string   :unlock_token # Only if unlock strategy is :email or :both
-      t.datetime :locked_at
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
 
 
       # Uncomment below if timestamps were not included in your original model.
       # t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
-    add_index :users, :reset_password_token, unique: true
-    add_index :users, :confirmation_token,   unique: true
-    add_index :users, :unlock_token,         unique: true
+    #add_index :users, :email,                unique: true
+    #add_index :users, :reset_password_token, unique: true
+    #add_index :users, :confirmation_token,   unique: true
+    #add_index :users, :unlock_token,         unique: true
   end
 
   def self.down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,27 +14,17 @@
 ActiveRecord::Schema.define(version: 20150814004520) do
 
   create_table "users", force: :cascade do |t|
-    t.string   "name",                                   null: false
-    t.boolean  "admin",                  default: false, null: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
+    t.string   "name",                                null: false
+    t.boolean  "admin",               default: false, null: false
+    t.string   "email",               default: "",    null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.datetime "remember_created_at"
-    t.string   "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
-    t.integer  "failed_attempts",        default: 0,     null: false
-    t.string   "unlock_token"
-    t.datetime "locked_at"
+    t.integer  "sign_in_count",       default: 0,     null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
   end
-
-  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-  add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true
 
 end


### PR DESCRIPTION
While setting up for next meetup, I discovered that a good portion of the devise fields we added are going to have conflicts with Github Omniauth login. So this PR will simplify things so that we can focus on one login scheme (Github Omniauth). As such, we'll only be using three of the Devise configurations:
1. `:trackable` - to get statistical/troubleshooting information about a user login
2. `:rememberable` - to allow for session expiration via cookies
3. `:omniauthable` - to allow Github login (we'll be adding this next meetup)

NOTE: This PR will not provide a sign-in page via Devise. We'll be adding our own login logic during next meetup.

Because I modified the migrations (protip: don't do this if you're working with an app that's been deployed), you'll need to drop and recreate your local database.

```
bundle exec rake db:drop
bundle exec rake db:create
bundle exec rake db:migrate
```
